### PR TITLE
fix: handle empty rm with xargs

### DIFF
--- a/.github/workflows/jekyll-link-checker.yml
+++ b/.github/workflows/jekyll-link-checker.yml
@@ -64,8 +64,9 @@ jobs:
       - name: Clean redirections
         run: |
           # Remove the redirect-files before link-check
-          find _site/ -name \*.html | \
-            xargs grep -l "Click here if you are not redirected." | xargs rm
+          find _site/ -name \*.html -print0 | \
+            xargs -0 -n 100 --no-run-if-empty grep -l "Click here if you are not redirected." || true | \
+            xargs --no-run-if-empty rm
 
       - name: Clean code elements from html
         run: |


### PR DESCRIPTION
## What

- Adds the `--no-run-if-empty` argument to `xargs` to ensure the `rm` command is not run without arguments.
- Handles the case where `grep` exits with status code 1 because no matches are found.

## Why

This ensures that if no file is matched in the "Clean redirections" step the workflow won't fail.


Example:
https://github.com/vespa-engine/sample-apps/actions/runs/10370346912/job/28708010858

- ![image](https://github.com/user-attachments/assets/8b120b6f-fe84-47da-b95d-c773c0f4963b)
- ![image](https://github.com/user-attachments/assets/2dea4a61-eda8-4371-b31a-0fb010f36b41)


---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
