### PR TITLE
feat: Update branch names in CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,10 @@ name: Lint
 on:
   push:
     branches:
-      - 1.x
+      - main
   pull_request:
     branches:
-      - 1.x
+      - main
 
 defaults:
   run:


### PR DESCRIPTION
## What
Modify the CI workflow to target the 'main' branch instead of the '1.x' branch. 

## Why

This ensures the workflow runs on the correct branch and aligns with the project's main branch naming convention.

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
